### PR TITLE
Return api fetches to modular files

### DIFF
--- a/src/APICalls.js
+++ b/src/APICalls.js
@@ -1,14 +1,8 @@
 const getData = dataset => {
-  let data = [];
-  fetch(`http://localhost:3001/api/v1/${dataset}`)
+  return fetch(`http://localhost:3001/api/v1/${dataset}`)
     .then(response => response.json())
-    .then(result => {
-      result.forEach(eachResult => {
-        data.push(eachResult)
-      });
-    })
-    .catch(error => console.log('error', error));
-  return data;
+    .then(data => data)    
+    .catch(error => console.log('error', error));  
 } 
 
 // export const sendData = dataToSend => {

--- a/src/data/ingredient-data.js
+++ b/src/data/ingredient-data.js
@@ -2,9 +2,8 @@ import getData from '../APICalls';
 
 const apiCall = 'ingredients';
 
-
 let ingredientsData;
 
-ingredientsData = getData(apiCall);
+ingredientsData = getData(apiCall);  
 
 export default ingredientsData;

--- a/src/data/recipe-data.js
+++ b/src/data/recipe-data.js
@@ -4,6 +4,6 @@ const apiCall = 'recipes';
 
 let recipeData;
 
-recipeData = getData(apiCall);
+recipeData = getData(apiCall);  
 
 export default recipeData;

--- a/src/data/users-data.js
+++ b/src/data/users-data.js
@@ -3,6 +3,6 @@ import getData from '../APICalls';
 const apiCall = 'users';
 let users;
 
-users = getData(apiCall);
+users = getData(apiCall);  
 
 export default users;

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-len */
-// import users from './data/users-data.js';
-// import recipeData from  './data/recipe-data';
+import users from './data/users-data.js';
+import recipeData from  './data/recipe-data';
 import ingredientsData from './data/ingredient-data';
 
 import './css/base.scss';
@@ -15,7 +15,6 @@ import domUpdates from './domUpdates';
 import User from './user';
 import RecipeRepo from './recipe-repo'
 import IngredientsRepo from './ingredient-repo'
-import apiCalls from './APICalls.js';
 
 let allRecipesBtn = document.querySelector(".show-all-btn");
 let filterBtn = document.querySelector(".filter-btn");
@@ -35,14 +34,7 @@ let recipes = [];
 let ingredientsRepo;  
 
 const initiateData = () => {
-  const usersPromise = fetch('http://localhost:3001/api/v1/users')
-    .then(response => response.json());
-  const ingredientsPromise = fetch('http://localhost:3001/api/v1/ingredients')
-    .then(response => response.json());
-  const recipesPromise = fetch('http://localhost:3001/api/v1/recipes')
-    .then(response => response.json());
-
-  const promises = [usersPromise, ingredientsPromise, recipesPromise];
+  const promises = [users, ingredientsData, recipeData];
   Promise.all(promises)
     .then(data => {      
       user = new User(data[0][Math.floor(Math.random() * data[0].length)]);


### PR DESCRIPTION
**What does this PR do?**
- this pr makes the api fetches for initial data modular again
  - we are now importing the promises, and giving those to the `Promise.all()` in `initiateData()` in `scripts.js`
**What does it fix?**
- calls were not modular after the first refactor
**Is this a feature or a fix?**
- fix
**Where should the reviewer start?**
- `APICalls.js`
**How should this be tested?**
- pull down branch locally (not to main)
- run servers
- observe differences in `APICalls.js`


- [x] Did you test your code locally first?
- [x] Does this follow our intended guidelines (DRY & commented) for project code?

- this closes to #78